### PR TITLE
Fix for merging chapters.txt files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/older-versions/

--- a/auto-m4b-tool.sh
+++ b/auto-m4b-tool.sh
@@ -101,8 +101,8 @@ while [ $m -ge 0 ]; do
 				logfile="$outputfolder$book/$book$logend"
 				chapters=$(ls "$inputfolder$book"/*chapters.txt 2> /dev/null | wc -l)
 				if [ "$chapters" != "0" ]; then
-					echo Adjusting Chapters
-					mp4chaps -i "$inputfolder""$book"/*$m4bend
+				        echo "Merging chapters file found in directory named "$book" into media file."
+          				mp4chaps -i "$inputfolder$book"/*$m4bend
 					mv "$inputfolder$book" "$outputfolder"
 				else
 					echo Sampling $mpthree


### PR DESCRIPTION
The current formatting of the mp4chaps command doesn't work correctly if you want to include an updated chapters file and re-merge them into the m4b file.  This corrects the formatting of that line to make it work.