### PR TITLE
Add support for processing audiobooks with nested subfolders

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Use the [beets.io audible plugin](https://github.com/seanap/beets-audible) to fi
 ## Known Limitations
 
 * The chapters are based on the mp3 tracks. A single mp3 file will become a single m4b with 1 chapter, also if the mp3 filenames are garbarge then your m4b chapternames will be terrible as well.  See section on Chapters below for how to manually adjust.  
-* Right now book folders with nested subfolders will be moved to a /fix folder for manual filename/folder fixing.  It should be possible to modify the auto-m4b-tool.sh script to automatically prefix the subfoldername and move the files up a level, let me know if you know how to do this.  
 * The conversion process actually strips some tags and covers from the files, which is why you need to use a tagger (mp3tag or beets.io) before adding to Plex.
 
 ## Need ARM Support?
@@ -50,7 +49,7 @@ temp
 │           │   book4.m4b
 └───delete # needed by the script
 |
-└───fix # Manually fix books with nested folders
+└───fix # Manually fix books
 |
 └───backup # Backups incase anything goes wrong
       └─────book2


### PR DESCRIPTION
This PR adds the functionality to process audiobooks that have nested subfolders. 

Before the script moves files to the /temp/merge directory for processing, it will search for any audiobook folders that contain nested subfolders. 

If any are found it will go through all subfolders and prepend the subfolder names to the front of each filename and move the file into the grandparent directory (2 levels deep).

The script will then proceed as usual and move all audiobook folders into /temp/merge for processing.

